### PR TITLE
corrected reference to "wad2xml" to "map2xml"

### DIFF
--- a/map-extras/commands.sh
+++ b/map-extras/commands.sh
@@ -6,9 +6,9 @@
 ./macbin2data.pl < "Marathon Infinity"/Map.sceA > M3.map
 
 # create XML
-./wad2xml.pl < M1.map > M1.xml
-./wad2xml.pl < M2.map > M2.xml
-./wad2xml.pl < M3.map > M3.xml
+./map2xml.pl < M1.map > M1.xml
+./map2xml.pl < M2.map > M2.xml
+./map2xml.pl < M3.map > M3.xml
 
 # generate automap-style images with markers
 ./mapxml2images.pl -dir M1o -ignore map-extras/M1_ignored_polys.txt -font map-extras/ProFontAO.ttf -zoom -html -scales -mark -legend < M1.xml


### PR DESCRIPTION
commands.sh references `wad2xml.pl`, but this script doesn't exist in any repo that I could find and the existing `map2xml.pl` does exist and appears to perform the expected function of that step.